### PR TITLE
Fixed crash when uri encoding pound sign

### DIFF
--- a/t/20_cookie_baker_bake.t
+++ b/t/20_cookie_baker_bake.t
@@ -9,6 +9,7 @@ exit main();
 sub main {
     test_bake_simple();
     test_bake_time();
+    test_url_encode();
     done_testing();
 
     return 0;
@@ -60,6 +61,12 @@ sub test_bake_time {
 
         is( sc(bake_cookie('foo', $value)), sc($expected), $test->[0] );
     }
+}
+
+sub test_url_encode {
+
+    is bake_cookie( 'test', "!\"\x{a3}\$%^*(*^%\$\x{a3}\":1" ),
+        'test=%21%22%a3%24%25%5e%2a%28%2a%5e%25%24%a3%22%3a1';
 }
 
 sub fmt {

--- a/uri.c
+++ b/uri.c
@@ -53,7 +53,13 @@ Buffer* url_encode(Buffer* src, int length,
     int s = src->pos;
     int t = tgt->pos;
     while (s < (src->pos + length)) {
-        char* v = uri_encode_tbl[(int)src->data[s]];
+        /* NOTE: masked the character array in case of platforms
+         * with >8 bit chars since our table only has sufficient
+         * characters for that many conversions.
+         * Results will potentially be wrong in that case,
+         * but at least we won't crash.
+         */
+        char* v = uri_encode_tbl[((unsigned char)src->data[s])&0xff];
 
         /* if current source character doesn't need to be encoded,
            just copy it to target*/


### PR DESCRIPTION
This prevents a segfault when url encoding £.

```
Segmentation fault (Signal sent by the kernel)
/usr/local/lib/x86_64-linux-gnu/perl/5.22.1/auto/HTTP/XSCookies/XSCookies.so(url_encode+0x40)[0x7f72271e7180]
/usr/local/lib/x86_64-linux-gnu/perl/5.22.1/auto/HTTP/XSCookies/XSCookies.so(+0x33c1)[0x7f72271e63c1]
/usr/local/lib/x86_64-linux-gnu/perl/5.22.1/auto/HTTP/XSCookies/XSCookies.so(cookie_put_string+0xe)[0x7f72271e64ae]
/usr/local/lib/x86_64-linux-gnu/perl/5.22.1/auto/HTTP/XSCookies/XSCookies.so(+0x2c2d)[0x7f72271e5c2d]
perl(Perl_pp_entersub+0x48a)[0x4bd3ca]
perl(Perl_runops_standard+0x16)[0x4b6276]
perl(perl_run+0x2f9)[0x443c59]
perl(main+0x12b)[0x41cbbb]
/lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0xf0)[0x7f7227d34830]
perl(_start+0x29)[0x41cbf9]
Segmentation fault (core dumped)
```